### PR TITLE
Fix build with vala 0.56

### DIFF
--- a/src/Vocal.vala
+++ b/src/Vocal.vala
@@ -64,7 +64,7 @@ namespace Vocal {
             set_options ();
         }
 
-        public const OptionEntry[] app_options = {
+        private const OptionEntry[] app_options = {
             { "hidden", 'h', 0, OptionArg.NONE, out Option.OPEN_HIDDEN, "Open without displaying the window so podcasts will continue to update", null },
             { null }
         };


### PR DESCRIPTION
Otherwise the build fails with

```
/build/source/src/Vocal.vala:65.50-68.9: error: value is less accessible than constant `Vocal.VocalApp.app_options'
   65 |         public const OptionEntry[] app_options = {
      |                                                  ^
   66 |             { "hidden", 'h', 0, OptionArg.NONE, out Option.OPEN_HIDDEN, "Open without displaying the window so podcasts will continue to update", null },
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   67 |             { null }
      | ~~~~~~~~~~~~~~~~~~~~
   68 |         };
      | ~~~~~~~~~ 
Command-line option `--thread` is deprecated and will be ignored
Compilation failed: 1 error(s), 0 warning(s)
ninja: build stopped: subcommand failed.
```

See also: https://github.com/elementary/mail/pull/765